### PR TITLE
ability to publish a record to a topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,8 @@ err := client.CompleteRecord(record)
 err := client.FailRecord(record)
 ```
 
-
+### Publish New Record 
+```
+err := client.PublishRecord(data)
+```
 


### PR DESCRIPTION
- separated `data` from `record` so it could be used standalone - when publishing.